### PR TITLE
add UseHttps and UserAgent options

### DIFF
--- a/src/DaybreakGames.Census/CensusClient.cs
+++ b/src/DaybreakGames.Census/CensusClient.cs
@@ -27,6 +27,10 @@ namespace DaybreakGames.Census
 
             _client = new HttpClient();
 
+            if (options.Value.UserAgent != null) {
+                _client.DefaultRequestHeaders.UserAgent.TryParseAdd(options.Value.UserAgent);
+            }
+
             _serializerOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = new UnderscorePropertyJsonNamingPolicy(),
@@ -167,7 +171,7 @@ namespace DaybreakGames.Census
             var ns = query.ServiceNamespace ?? _options.Value.CensusServiceNamespace;
 
             var encArgs = query.ToString();
-            return new Uri($"http://{endpoint}/s:{sId}/get/{ns}/{encArgs}");
+            return new Uri($"http{(_options.Value.UseHttps ? "s" : "")}://{endpoint}/s:{sId}/get/{ns}/{encArgs}");
         }
 
         private void HandleCensusExceptions(Exception ex, Uri query)

--- a/src/DaybreakGames.Census/CensusOptions.cs
+++ b/src/DaybreakGames.Census/CensusOptions.cs
@@ -6,6 +6,8 @@
         public string CensusServiceNamespace { get; set; } = Constants.DefaultServiceNamespace;
         public string CensusApiEndpoint { get; set; } = Constants.CensusEndpoint;
         public string CensusWebsocketEndpoint { get; set; } = Constants.CensusWebsocketEndpoint;
+        public string UserAgent { get; set; } = null;
+        public bool UseHttps { get; set; } = false;
         public bool LogCensusErrors { get; set; } = false;
     }
 }

--- a/test/DaybreakGames.Census.Test/CensusURITest.cs
+++ b/test/DaybreakGames.Census.Test/CensusURITest.cs
@@ -364,12 +364,32 @@ namespace DaybreakGames.Census.Test
             Assert.AreEqual(expectedUri, censusUri);
         }
 
-        private CensusQueryFactory GetCensusQueryFactory()
+        [TestMethod]
+        public void Census_TestHttps()
+        {
+            var service = "character";
+            var ns = "ps2";
+            var key = "testkey";
+
+            var expectedUri = new Uri($"https://{Constants.CensusEndpoint}/s:{key}/get/{ns}/{service}/?c:hide=field1,field2,field3");
+
+            var query = GetCensusQueryFactory(useHttps: true).Create(service);
+
+            query.HideFields(new[] { "field1", "field2", "field3" });
+
+            var censusUri = query.GetUri();
+
+            Assert.AreEqual(expectedUri, censusUri);
+        }
+
+        private CensusQueryFactory GetCensusQueryFactory(bool useHttps = false)
         {
             var options = new CensusOptions
             {
                 CensusServiceId = "testkey",
-                CensusServiceNamespace = "ps2"
+                CensusServiceNamespace = "ps2",
+                UserAgent = "test",
+                UseHttps = useHttps
             };
 
             var censusClient = new CensusClient(Options.Create(options), null);


### PR DESCRIPTION
adds an option for setting the UserAgent used to make the Census requests and allows for HTTPS calls

the UserAgent is needed as under certain conditions, requests without a UserAgent are blocked on Census